### PR TITLE
Add ghsa-sync-jira workflow

### DIFF
--- a/.github/workflows/ghsa-sync-jira.yml
+++ b/.github/workflows/ghsa-sync-jira.yml
@@ -1,0 +1,18 @@
+name: GitHub Security Alerts for Jira
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+
+jobs:
+  syncSecurityAlerts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Sync security alerts to Jira issues"
+        uses: reload/github-security-jira@v1.x
+        env:
+          GH_SECURITY_TOKEN: ${{ secrets.GH_TOKEN }}
+          JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+          JIRA_HOST: ${{ secrets.JIRA_HOST_URL }}
+          JIRA_USER: ${{ secrets.JIRA_USER }}
+          JIRA_PROJECT: SEC


### PR DESCRIPTION
Adds a workflow to sync GH security alerts to Jira every 6 hours.